### PR TITLE
automatically persist state

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 class Tonic extends window.HTMLElement {
   constructor () {
     super()
+    this.id = this.id || Tonic._createId()
     const state = Tonic._states[this.id]
     delete Tonic._states[this.id]
     this.isTonicComponent = true
@@ -14,7 +15,7 @@ class Tonic extends window.HTMLElement {
   }
 
   static _createId () {
-    return Math.random().toString(16).slice(2)
+    return `tonic_${Tonic._index++}`
   }
 
   static _maybePromise (p) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "benchmark": "^2.1.4",
     "browserify": "^16.2.2",
     "raynos-tape-puppet": "0.1.7-raynos2",
+    "simulate-event": "1.4.0",
     "standard": "14.3.1",
     "tape": "^4.11.0",
     "terser": "^4.0.2"

--- a/test/index.js
+++ b/test/index.js
@@ -178,7 +178,8 @@ test('automatically remember the state of a component', t => {
   container.reRender()
 
   window.requestAnimationFrame(() => {
-    t.equal(child.getState().foo, true, 'the state persisted')
+    const child2 = container.querySelector('component-stateful')
+    t.equal(child2.getState().foo, true, 'the state persisted')
     t.end()
   })
 })


### PR DESCRIPTION
This PR ensures each tonic element has an id. The id is used to persist the state across re-renders. This should address https://github.com/optoolco/components/pull/40 at a higher level with less code.