### PR TITLE
src: Find event handler methods on proto

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,17 @@ class Tonic extends window.HTMLElement {
     return el.matches(s) ? el : el.closest(s)
   }
 
+  static getPropertyNames (proto) {
+    const props = []
+    while (proto && proto !== Tonic.prototype) {
+      props.push(...Object.getOwnPropertyNames(proto))
+      proto = Object.getPrototypeOf(proto)
+    }
+    return props
+  }
+
   static add (c) {
-    c.prototype._props = Object.getOwnPropertyNames(c.prototype)
+    c.prototype._props = Tonic.getPropertyNames(c.prototype)
 
     if (!c.name || c.name.length === 1) {
       throw Error('Mangling. https://bit.ly/2TkJ6zP')


### PR DESCRIPTION
When you use base classes for inheritance ( like `data-table` )
That implement event handlers, we want to find the event handler
methods on the parent class not just on the child class.

This can happen when you do

```
class DataTable extends Windowed {
  click (ev) { ... }
}

class GroupsDataTable extends DataTable {
  connected() { this.load([...]) }

  renderRow() { ... }
}
Tonic.add(GroupsDataTable)
```

Here the concrete DataTable that populates rows does not
implement a click handler so Tonic will not listen to
click events in the component even though the parent class
implements a click handler.