### PR TITLE
src: Fix reRender + updated event order bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,10 +135,9 @@ class Tonic extends window.HTMLElement {
     this.pendingReRender = new Promise(resolve => {
       window.requestAnimationFrame(() => {
         Tonic._maybePromise(this._set(this.root, this.render))
+        this.pendingReRender = null
 
         if (this.updated) this.updated(oldProps)
-
-        this.pendingReRender = null
         resolve()
       })
     })


### PR DESCRIPTION
There is a subtle bug related to `reRender()` and `updated`.

We attempt to invoke the `updated` lifecycle hook on a component
if the `reRender()` has finished and the props are updated.

However, we null out the `pendingReRender` too late, since the
`updated` method can dispatch a DOM event ( e.g. `changed` )
which can trigger a reRender in an event listener.

We should set our internal state correctly before calling the
lifecycle `updated` method.

This fixes a bug in `components/checkbox`.