### PR TITLE
Improve saniziation + Tonic.raw()

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,9 +13,9 @@
 
 | Method | Description |
 | :--- | :--- |
-| `add(Class)` | Register a class as a new custom-tag and provide options for it. |
+| `add(Class, String?)` | Register a class as a new custom-tag and provide options for it. You can pass an optional string that is the HTML tagName for the custom component.|
 | `escape(String)` | Escapes HTML characters from a string (based on [he][3]). |
-| `sanitize(Object)` | Escapes all the strings found in an object literal. |
+| `raw(String)` | Insert raw text in html\`...\`. Useful when calling `super.render()` or otherwise delegating to `render()` of another component. Be careful with calling `raw` on untrusted text like user input as that is an XSS attack vector.
 | `match(Node, Selector)` | Match the given node against a selector or any matching parent of the given node. This is useful when trying to locate a node from the actual node that was interacted with. |
 
 ## INSTANCE METHODS

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,7 +6,7 @@ of `@optoolco/tonic`.
 The main takeaway is that v10 had a potential XSS injection as
 we only escaped strings that exist on `this.props.someKey`,
 we've now changed the implementation to sanitize all strings
-that are passed into `this.html\`<div>${someStr}<div>\``.
+that are passed into ``this.html`<div>${someStr}<div>```.
 
 This breaks some existing patterns that are common in applications
 like the following

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,65 @@
+# Migrating from v10 to v11
+
+The implementation of HTML escaping changed between v10 and v11
+of `@optoolco/tonic`.
+
+The main takeaway is that v10 had a potential XSS injection as
+we only escaped strings that exist on `this.props.someKey`,
+we've now changed the implementation to sanitize all strings
+that are passed into `this.html\`<div>${someStr}<div>\``.
+
+This breaks some existing patterns that are common in applications
+like the following
+
+```js
+class Comp extends Windowed {
+  render () {
+    return this.html`
+      <div>
+        <header>Some header</header>
+        ${super.render()}
+      </div>
+    `
+  }
+}
+```
+
+Or
+
+```js
+class Toaster extends Tonic {
+  render () {
+    return this.html`
+      <div>
+        ${this.renderIcon()}
+        ${this.renderLabel()}
+        <div>${title}</div>
+      </div>
+    `
+  }
+}
+```
+
+In both cases the HTML returned from either `super.render()` or
+from `this.renderIcon()` is now being escaped which is probably
+not the desired behavior.
+
+You will have to patch the code to call
+`${Tonic.raw(this.renderIcon())}` or
+`${Tonic.raw(super.render())}`
+
+If you want to quickly find all occurences of the above patterns
+you can run the following git grep on your codebase.
+
+```sh
+git grep -C10 '${' | grep ')}'
+```
+
+The fix is to add `Tonic.raw()` calls in various places.
+
+We have updated `@optoolco/components` and you will have to
+update to version `7.4.0` as well
+
+```sh
+npm install @optoolco/components@^7.4.0 -ES
+```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,3 +92,43 @@ Here is a regex you can use to find the one-liner use cases.
 ```
 git grep -E '`(.+)="'
 ```
+
+When building dynamic attribute lists `Tonic` has a spread feature
+in the `this.html()` function you can use instead to make it easier.
+
+For example, you can refactor the above `Icon` class to:
+
+```js
+class Icon extends Tonic {
+  render () {
+    return this.html`<svg ${tabAttr} styles="icon">
+      <use ...${{
+        width: size,
+        fill,
+        color: fill,
+        height: size
+      }}>
+    </svg>`
+  }
+}
+```
+
+Here we use `...${{ ... }}` to expand an object of attributes to
+attribute key value pairs in the HTML. You can also pull out the attrs
+into a reference if you prefer, like:
+
+```js
+class Icon extends Tonic {
+  render () {
+    const useAttrs = {
+      width: size,
+      fill,
+      color: fill,
+      height: size
+    }
+    return this.html`<svg ${tabAttr} styles="icon">
+      <use ...${useAttrs}>
+    </svg>`
+  }
+}
+```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,41 +12,46 @@ This breaks some existing patterns that are common in applications
 like the following
 
 ```js
-class Comp extends Windowed {
+class Comp extends Tonic {
+  renderLabel () {
+    return `<label>${this.props.label}</label>`
+  }
+
   render () {
     return this.html`
       <div>
         <header>Some header</header>
-        ${super.render()}
+        ${this.renderLabel()}
       </div>
     `
   }
 }
 ```
 
-Or
+In this case the HTML returned from `this.renderLabel()` is now
+being escaped which is probably not what you meant.
+
+You will have to patch the code to use `this.html` for the
+implementation of `renderLabel()` like
 
 ```js
-class Toaster extends Tonic {
+  renderLabel () {
+    return this.html`<label>${this.props.label}</label>`
+  }
+```
+
+Or to call `Tonic.raw()` manually like
+
+```js
   render () {
     return this.html`
       <div>
-        ${this.renderIcon()}
-        ${this.renderLabel()}
-        <div>${title}</div>
+        <header>Some header</header>
+        ${Tonic.raw(this.renderLabel())}
       </div>
     `
   }
-}
 ```
-
-In both cases the HTML returned from either `super.render()` or
-from `this.renderIcon()` is now being escaped which is probably
-not the desired behavior.
-
-You will have to patch the code to call
-`${Tonic.raw(this.renderIcon())}` or
-`${Tonic.raw(super.render())}`
 
 If you want to quickly find all occurences of the above patterns
 you can run the following git grep on your codebase.
@@ -55,7 +60,7 @@ you can run the following git grep on your codebase.
 git grep -C10 '${' | grep ')}'
 ```
 
-The fix is to add `Tonic.raw()` calls in various places.
+The fix is to add `this.html` calls in various places.
 
 We have updated `@optoolco/components` and you will have to
 update to version `7.4.0` as well

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,3 +63,32 @@ update to version `7.4.0` as well
 ```sh
 npm install @optoolco/components@^7.4.0 -ES
 ```
+
+There are other situations in which the increased escaping from
+`Tonic.escape()` like for example escaping the `"` character if
+you dynamically generate optional attributes
+
+Like:
+
+```js
+class Icon extends Tonic {
+  render () {
+    return this.html`<svg ${tabAttr} styles="icon">
+      <use
+        width="${size}"
+        ${fill ? `fill="${fill}" color="${fill}"` : ''}
+        height="${size}">
+    </svg>`
+  }
+}
+```
+
+In the above example we do ``fill ? `fill="${fill}"` : ''`` which
+leads to `"` getting escaped to `&quot;` and leads to the value
+of `use.getAttribute('fill')` to be `"${fill}"` instead of `${fill}`
+
+Here is a regex you can use to find the one-liner use cases.
+
+```
+git grep -E '`(.+)="'
+```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,7 +6,7 @@ of `@optoolco/tonic`.
 The main takeaway is that v10 had a potential XSS injection as
 we only escaped strings that exist on `this.props.someKey`,
 we've now changed the implementation to sanitize all strings
-that are passed into ``this.html`<div>${someStr}<div>```.
+that are passed into ``this.html`<div>${someStr}<div>`;``.
 
 This breaks some existing patterns that are common in applications
 like the following

--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@
 </p>
 <br/>
 <br/>
+
+For more info see
+
+ - [HELP.md][help]
+ - [API.md][api]
+ - [MIGRATION.md][migration]
+
+## Install
+
+```
+% npm install @optoolco/tonic -S
+```
+
+## MIT Licensed
+
+  [help]: HELP.md
+  [api]: API.md
+  [migration]: MIGRATION.md

--- a/index.js
+++ b/index.js
@@ -96,9 +96,14 @@ class Tonic extends window.HTMLElement {
     return s.replace(Tonic.ESC, c => Tonic.MAP[c])
   }
 
+  static raw (s) {
+    return { isTonicRaw: true, rawText: s }
+  }
+
   html ([s, ...strings], ...values) {
     const refs = o => {
       if (o && o.__children__) return this._placehold(o)
+      if (o && o.isTonicRaw) return o.rawText
       switch (Object.prototype.toString.call(o)) {
         case '[object HTMLCollection]':
         case '[object NodeList]': return this._placehold([...o])

--- a/index.js
+++ b/index.js
@@ -325,6 +325,7 @@ Object.assign(Tonic, {
   _children: {},
   _reg: {},
   _index: 0,
+  version: require ? require('./package').version : null,
   SPREAD: /\.\.\.\s?(__\w+__\w+__)/g,
   ESC: /["&'<>`]/g,
   AsyncFunctionGenerator: async function * () {}.constructor,

--- a/index.js
+++ b/index.js
@@ -1,3 +1,13 @@
+class TonicRaw {
+  constructor (rawText) {
+    this.isTonicRaw = true
+    this.rawText = rawText
+  }
+
+  valueOf () { return this.rawText }
+  toString () { return this.rawText }
+}
+
 class Tonic extends window.HTMLElement {
   constructor () {
     super()
@@ -97,7 +107,7 @@ class Tonic extends window.HTMLElement {
   }
 
   static raw (s) {
-    return { isTonicRaw: true, rawText: s }
+    return new TonicRaw(s)
   }
 
   html ([s, ...strings], ...values) {
@@ -128,7 +138,8 @@ class Tonic extends window.HTMLElement {
     }
 
     const reduce = (a, b) => a.concat(b, strings.shift())
-    return values.map(refs).reduce(reduce, [s]).join('')
+    const str = values.map(refs).reduce(reduce, [s]).join('')
+    return Tonic.raw(str)
   }
 
   setState (o) {
@@ -188,6 +199,10 @@ class Tonic extends window.HTMLElement {
       return
     } else if (render instanceof Function) {
       content = render.call(this) || ''
+    }
+
+    if (content && content.isTonicRaw) {
+      content = content.rawText
     }
 
     if (typeof content === 'string') {

--- a/index.js
+++ b/index.js
@@ -195,8 +195,10 @@ class Tonic extends window.HTMLElement {
         const o = Tonic._data[p.split('__')[1]][p]
         return Object.entries(o).map(([key, value]) => {
           const k = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
-          return `${k}="${Tonic.escape(String(value))}"`
-        }).join(' ')
+          if (value === true) return k
+          else if (value) return `${k}="${Tonic.escape(String(value))}"`
+          else return ''
+        }).filter(Boolean).join(' ')
       })
 
       if (this.stylesheet) {
@@ -308,7 +310,7 @@ Object.assign(Tonic, {
   _children: {},
   _reg: {},
   _index: 0,
-  SPREAD: /\.\.\.(__\w+__\w+__)/g,
+  SPREAD: /\.\.\.\s?(__\w+__\w+__)/g,
   ESC: /["&'<>`]/g,
   AsyncFunctionGenerator: async function * () {}.constructor,
   AsyncFunction: async function () {}.constructor,

--- a/test/index.js
+++ b/test/index.js
@@ -58,9 +58,11 @@ test('Tonic escapes attribute injection', t => {
     render () {
       const userInput2 = '" onload="console.log(42)'
       const userInput = '"><script>console.log(42)</script>'
+      const userInput3 = 'a" onmouseover="alert(1)"'
 
       const input = this.props.input === 'script'
-        ? userInput : userInput2
+        ? userInput : this.props.input === 'space'
+          ? userInput3 : userInput2
 
       if (this.props.spread) {
         return this.html`
@@ -83,6 +85,10 @@ test('Tonic escapes attribute injection', t => {
   Tonic.add(Comp1, compName)
 
   document.body.innerHTML = `
+    <${compName} input="space" quoted="1"></${compName}>
+    <${compName} input="space" spread="1"></${compName}>
+    <!-- This is XSS attack below. -->
+    <${compName} input="space"></${compName}>
     <${compName} input="script" quoted="1"></${compName}>
     <${compName} input="script" spread="1"></${compName}>
     <${compName} input="script"></${compName}>
@@ -93,11 +99,12 @@ test('Tonic escapes attribute injection', t => {
   `
 
   const divs = document.querySelectorAll('div')
-  t.equal(divs.length, 6)
+  t.equal(divs.length, 9)
   for (let i = 0; i < divs.length; i++) {
     const div = divs[i]
     t.equal(div.childNodes.length, 0)
-    t.equal(div.hasAttribute('onload'), i === 5)
+    t.equal(div.hasAttribute('onmouseover'), i === 2)
+    t.equal(div.hasAttribute('onload'), i === 8)
   }
 
   t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,32 @@ test('attach to dom', t => {
   t.end()
 })
 
+test('Tonic escapes text', t => {
+  class Comp extends Tonic {
+    render () {
+      const userInput = this.props.userInput
+      return this.html`<div>${userInput}</div>`
+    }
+  }
+  const compName = `x-${uuid()}`
+  Tonic.add(Comp, compName)
+
+  const userInput = '<pre>lol</pre>'
+  document.body.innerHTML = `
+    <${compName} user-input="${userInput}"></${compName}>
+  `
+
+  const divs = document.querySelectorAll('div')
+  t.equal(divs.length, 1)
+  const div = divs[0]
+  t.equal(div.childNodes.length, 1)
+  t.equal(div.childNodes[0].nodeType, 3)
+  t.equal(div.innerHTML, '&lt;pre&gt;lol&lt;/pre&gt;')
+  t.equal(div.childNodes[0].data, '<pre>lol</pre>')
+
+  t.end()
+})
+
 test('attach to dom with shadow', t => {
   Tonic.add(class ShadowComponent extends Tonic {
     constructor (o) {

--- a/test/index.js
+++ b/test/index.js
@@ -126,7 +126,6 @@ test('pass props', t => {
   const bb = document.getElementById('y')
   {
     const props = bb.getProps()
-    console.log(JSON.stringify(props))
     t.equal(props.fn(), 'hello, world', 'passed a function')
     t.equal(props.number, 42.42, 'float parsed properly')
   }

--- a/test/index.js
+++ b/test/index.js
@@ -175,6 +175,43 @@ test('get element by id and set properties via the api', t => {
   })
 })
 
+test('inheritance and super.render()', t => {
+  class Stuff extends Tonic {
+    render () {
+      return '<div>nice stuff</div>'
+    }
+  }
+
+  class SpecificStuff extends Stuff {
+    render () {
+      return this.html`
+        <div>
+          <header>A header</header>
+          ${Tonic.raw(super.render())}
+        </div>
+      `
+    }
+  }
+
+  const compName = `x-${uuid()}`
+  Tonic.add(SpecificStuff, compName)
+
+  document.body.innerHTML = `
+    <${compName}></${compName}>
+  `
+
+  const divs = document.querySelectorAll('div')
+  t.equal(divs.length, 2)
+
+  const first = divs[0]
+  t.equal(first.childNodes.length, 5)
+  t.equal(first.childNodes[1].tagName, 'HEADER')
+  t.equal(first.childNodes[3].tagName, 'DIV')
+  t.equal(first.childNodes[3].textContent, 'nice stuff')
+
+  t.end()
+})
+
 test('construct from api', t => {
   document.body.innerHTML = ''
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,11 @@ const sleep = t => new Promise(resolve => setTimeout(resolve, t))
 
 test('sanity', t => {
   t.ok(true)
+
+  const version = Tonic.version
+  const parts = version.split('.')
+  t.ok(parseInt(parts[0]) >= 10)
+
   t.end()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -212,6 +212,43 @@ test('inheritance and super.render()', t => {
   t.end()
 })
 
+test('Tonic#html returns raw string', t => {
+  class Stuff extends Tonic {
+    render () {
+      return this.html`<div>nice stuff</div>`
+    }
+  }
+
+  class SpecificStuff extends Stuff {
+    render () {
+      return this.html`
+        <div>
+          <header>A header</header>
+          ${super.render()}
+        </div>
+      `
+    }
+  }
+
+  const compName = `x-${uuid()}`
+  Tonic.add(SpecificStuff, compName)
+
+  document.body.innerHTML = `
+    <${compName}></${compName}>
+  `
+
+  const divs = document.querySelectorAll('div')
+  t.equal(divs.length, 2)
+
+  const first = divs[0]
+  t.equal(first.childNodes.length, 5)
+  t.equal(first.childNodes[1].tagName, 'HEADER')
+  t.equal(first.childNodes[3].tagName, 'DIV')
+  t.equal(first.childNodes[3].textContent, 'nice stuff')
+
+  t.end()
+})
+
 test('construct from api', t => {
   document.body.innerHTML = ''
 


### PR DESCRIPTION
This adds a new feature `Tonic.raw()` and it also
changes the escape implementation for `Tonic#html`

Instead of mutating `this.props` and making sure
all nested strings are escaped we escape all strings
that you pass in as placeholders in `Tonic#html`.

The caveat here is that it breaks injecting html
directly which can now be addressed by calling
`Tonic.raw()` which will embed a raw string in place.

r: @heapwolf