### PR TITLE
support passing null value as prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,11 +119,12 @@ class Tonic extends window.HTMLElement {
           return this._prop(Tonic._normalizeAttrs(o))
         case '[object Number]': return `${o}__float`
         case '[object Boolean]': return `${o}__boolean`
+        case '[object Null]': return `${o}__null`
         case '[object HTMLElement]':
           return this._placehold([o])
       }
       if (
-        typeof o === 'object' && o.nodeType === 1 &&
+        typeof o === 'object' && o && o.nodeType === 1 &&
         typeof o.cloneNode === 'function'
       ) {
         return this._placehold([o])
@@ -270,6 +271,8 @@ class Tonic extends window.HTMLElement {
         this.props[name] = Tonic._data[root][p]
       } else if (/\d+__float/.test(p)) {
         this.props[name] = parseFloat(p, 10)
+      } else if (p === 'null__null') {
+        this.props[name] = null
       } else if (/\w+__boolean/.test(p)) {
         this.props[name] = p.includes('true')
       } else if (/placehold:\w+:\w+__/.test(p)) {

--- a/test/index.js
+++ b/test/index.js
@@ -794,9 +794,30 @@ test('default props', t => {
   t.end()
 })
 
-test('cleanup, ensure exist', t => {
+test('Tonic comp with null prop', t => {
+  class InnerComp extends Tonic {
+    render () {
+      return this.html`<div>${String(this.props.foo)}</div>`
+    }
+  }
+  const innerName = `x-${uuid()}`
+  Tonic.add(InnerComp, innerName)
+
+  class OuterComp extends Tonic {
+    render () {
+      return this.html`<${innerName} foo=${null}></${innerName}>`
+    }
+  }
+  const outerName = `x-${uuid()}`
+  Tonic.add(OuterComp, outerName)
+
+  document.body.innerHTML = `<${outerName}></${outerName}>`
+
+  const div = document.body.querySelector('div')
+  t.ok(div)
+
+  t.equal(div.textContent, 'null')
   t.end()
-  document.body.classList.add('finished')
 })
 
 test('re-render nested component', t => {
@@ -876,4 +897,9 @@ test('re-render nested component', t => {
 
     t.end()
   }
+})
+
+test('cleanup, ensure exist', t => {
+  t.end()
+  document.body.classList.add('finished')
 })


### PR DESCRIPTION
Previously this would throw an exception with
trying to access the `nodeType` field of `null`.

Now we just pass `null` down if the user wants to
pass null around.

r: @heapwolf