### PR TITLE
src: Ensure this.root is not undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,13 @@ class Tonic extends window.HTMLElement {
     if (this.pendingReRender) return this.pendingReRender
 
     this.pendingReRender = new Promise(resolve => window.setTimeout(() => {
-      const p = this._set(this.root, this.render)
+      /**
+       * this.root is sometimes undefined for no reason ...
+       * Use `this.root || this` to avoid uncaught exception.
+       *
+       * Something something, promises, async, setTimeout, race conditions.
+       */
+      const p = this._set(this.root || this, this.render)
       this.pendingReRender = null
 
       if (p && p.then) {
@@ -347,7 +353,7 @@ class Tonic extends window.HTMLElement {
         this.innerHTML = this._source
       }
 
-      const p = this._set(this.root, this.render)
+      const p = this._set(this.root || this, this.render)
       if (p && p.then) return p.then(() => this.connected && this.connected())
     }
 

--- a/index.js
+++ b/index.js
@@ -190,13 +190,7 @@ class Tonic extends window.HTMLElement {
     if (this.pendingReRender) return this.pendingReRender
 
     this.pendingReRender = new Promise(resolve => window.setTimeout(() => {
-      /**
-       * this.root is sometimes undefined for no reason ...
-       * Use `this.root || this` to avoid uncaught exception.
-       *
-       * Something something, promises, async, setTimeout, race conditions.
-       */
-      const p = this._set(this.root || this, this.render)
+      const p = this._set(this.shadowRoot || this, this.render)
       this.pendingReRender = null
 
       if (p && p.then) {
@@ -353,7 +347,7 @@ class Tonic extends window.HTMLElement {
         this.innerHTML = this._source
       }
 
-      const p = this._set(this.root || this, this.render)
+      const p = this._set(this.shadowRoot || this, this.render)
       if (p && p.then) return p.then(() => this.connected && this.connected())
     }
 


### PR DESCRIPTION
The logs application has an uncaught exception related
to `this.root` being undefined. Using `this.shadowRoot || this` avoids
the issue.

```
TypeError: Cannot read property 'querySelectorAll' of undefined
  at HTMLElement._set (/home/raynos/optoolco/logs/node_modules/@optoolco/tonic/index.js:254:31)
  at /home/raynos/optoolco/logs/node_modules/@optoolco/tonic/index.js:207:24
```

I could not figure out why it's undefined but using `this.shadowRoot || this`
definitely makes the uncaught exception go away and has the behavior
we want.