### PR TITLE
src: Add dispatch method

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,6 +24,7 @@
 | :--- | :--- |
 | <code>reRender(Object &#124; Function)</code> | Set the properties of a component instance. Can also take a function which will receive the current props as an argument. |
 | html\`...\` | Interpolated HTML string (use as a [tagged template][2]). Provides...<br/> 1. Pass object references as properties.<br/> 2. Spread operator (ie `<a ...${object}></a>`) which turns ojbects into html properties.<br/> 3. Automatic string escaping.<br/> 4. Render `NamedNodeMap`, `HTMLElement`, `HTMLCollection`, or `NodeList` as html (ie `<a>${span}</a>`).<br/>|
+| `dispatch(String, Object?)` | Dispatch a custom event from the component with an optional detail. A parent component can listen for the event by calling `this.addEventListener(String, this)` and implementing the event handler method. |
 
 ## INSTANCE PROPERTIES
 

--- a/index.js
+++ b/index.js
@@ -141,6 +141,11 @@ class Tonic extends window.HTMLElement {
     return new TonicTemplate(s, templateStrings, true)
   }
 
+  dispatch (eventName, detail = null) {
+    const opts = { bubbles: true, detail }
+    this.dispatchEvent(new window.CustomEvent(eventName, opts))
+  }
+
   html (strings, ...values) {
     const refs = o => {
       if (o && o.__children__) return this._placehold(o)


### PR DESCRIPTION
Small ergonomic improvement for dispatching a custom event
on a Tonic component.

A parent component can use `this.addEventListener(eventName, this)`
to listen for the event if it implements a method thats the
same as eventName.

This brings up the cloc count from 325 => 329.

r: @heapwolf