### PR TITLE
src: Tonic.add() should throw err with double add

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,9 @@ class Tonic extends window.HTMLElement {
     }
 
     if (!htmlName) htmlName = Tonic._splitName(c.name).toLowerCase()
-    if (window.customElements.get(htmlName)) return
+    if (window.customElements.get(htmlName)) {
+      throw new Error(`Cannot Tonic.add(${c.name}, '${htmlName}') twice`)
+    }
 
     if (!c.prototype.isTonicComponent) {
       const tmp = { [c.name]: class extends Tonic {} }[c.name]


### PR DESCRIPTION
Adding a component with the same name twice causes a subtle
race condition with the first one winning.

This is hard to debug / track down.

Throwing an error lets the user know where and what went
wrong.