### PR TITLE
simply accessing a the id property should not throw an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class Tonic extends window.HTMLElement {
     this._state = (this._checkId(), newState)
   }
 
-  get id () { return _id }
+  get id () { return _id  || ''}
 
   set id (newId) { super.id = newId }
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class Tonic extends window.HTMLElement {
     this._state = (this._checkId(), newState)
   }
 
-  get id () { return super.id ''g}
+  get id () { return super.id }
 
   set id (newId) { super.id = newId }
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class Tonic extends window.HTMLElement {
     this._state = (this._checkId(), newState)
   }
 
-  get id () { return _id  || ''}
+  get id () { return super.id ''g}
 
   set id (newId) { super.id = newId }
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class Tonic extends window.HTMLElement {
     this._state = (this._checkId(), newState)
   }
 
-  get id () { return this._checkId() }
+  get id () { return _id }
 
   set id (newId) { super.id = newId }
 


### PR DESCRIPTION
it should not throw just because something accesses the id property

expected behavior for an html element is for id to default to empty string.

I'm trying to write tests, and need to use log things about elements. throwing makes it much harder.