### PR TITLE
Remove redundant getter/setter

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,6 @@ class Tonic extends window.HTMLElement {
     this._state = (this._checkId(), newState)
   }
 
-  get id () { return super.id }
-
-  set id (newId) { super.id = newId }
-
   _events () {
     const hp = Object.getOwnPropertyNames(window.HTMLElement.prototype)
     for (const p of this._props) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+// @ts-check
+'use strict'
+
 class TonicTemplate {
   constructor (rawText, templateStrings, unsafe) {
     this.isTonicTemplate = true


### PR DESCRIPTION
I audited the rest of the class where we used `.id` and relied
on the `_checkId()` logic and there were basically no cases.

The important place where we call `_checkId()` is assignment
to `this.state` in the getter/setter.

I ended up removing the redundant getter/setter.